### PR TITLE
add implicit conversion from Step[A] to Either[Result, A]

### DIFF
--- a/app/controllers/ActionDSL.scala
+++ b/app/controllers/ActionDSL.scala
@@ -138,5 +138,7 @@ package object ActionDSL {
     }
 
     implicit def stepToResult(step: Step[Result]): Future[Result] = step.run.map(_.toEither.merge)(executionContext)
+
+    implicit def stepToEither[A](step: Step[A]): Future[Either[Result, A]] = step.run.map(_.toEither)(executionContext)
   }
 }


### PR DESCRIPTION
The conversion is useful in ActionFunction blocks that return
`Either[Result, Request]`.
