### PR TITLE
expose StepT[F[_], A] and Step[A]

### DIFF
--- a/app/controllers/ActionDSL.scala
+++ b/app/controllers/ActionDSL.scala
@@ -32,7 +32,9 @@ import scalaz._
  */
 package object ActionDSL {
 
-  type Step[A] = EitherT[Future, Result, A]
+  type StepT[F[_], A] = EitherT[F, Result, A]
+  type Step[A] = StepT[Future, A]
+
   type JsErrorContent = Seq[(JsPath, Seq[ValidationError])]
 
   private [ActionDSL] def fromFuture[A](onFailure: Throwable => Result)(future: Future[A])(implicit ec: ExecutionContext): Step[A] =
@@ -85,6 +87,9 @@ package object ActionDSL {
   trait MonadicActions {
 
     import scala.language.implicitConversions
+
+    type StepT[F[_], A] = ActionDSL.StepT[F, A]
+    type Step[A] = ActionDSL.Step[A]
 
     val executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
 

--- a/test/controllers/ExampleController.scala
+++ b/test/controllers/ExampleController.scala
@@ -6,6 +6,8 @@ import play.api.mvc.{Action, Controller}
 import scala.concurrent.Future
 import scala.util.Try
 
+import scalaz.syntax.monad._
+
 /**
  * @author Valentin Kasas
  */
@@ -16,8 +18,10 @@ object ExampleController extends Controller with MonadicActions {
   def action(idStr: String) = Action.async {
     request =>
       for {
-        id <- Try(idStr.toLong) ?| BadRequest
-        number <- service(id) ?| NotFound
+        id          <- Try(idStr.toLong) ?| BadRequest
+        constNumber <- 1                 .point[Step]
+        optNumber   <- service(id)       .liftM[StepT]
+        number      <- service(id)       ?| NotFound
       } yield Ok(number.toString)
   }
 


### PR DESCRIPTION
The type alias for the `StepT` monad transformer helps with using
`liftM[G: MonadTrans]` to lift a `Future[A]` directly to `Step[A]`.

The type alias for the `Step` monad helps with using `point[M: Monad]`
to lift an `A` directly to `Step[A]`.

See the ExampleController test for example usage.
