### PR TITLE
Reorganize cats compatibility module

### DIFF
--- a/cats/test/io/kanaka/play/CatsStepOpsSpec.scala
+++ b/cats/test/io/kanaka/play/CatsStepOpsSpec.scala
@@ -1,7 +1,8 @@
-package io.kanaka.play.cats
+package io.kanaka.play
 
-import _root_.cats.data.{Validated, Xor}
+import cats.data.{Validated, Xor}
 import controllers.ActionDSL.MonadicActions
+import io.kanaka.play.compat.cats._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Results
 import play.api.test.{FakeApplication, PlaySpecification}


### PR DESCRIPTION
Here's how I would organize the cat subproject.  Users see only clean imports:

``` scala
io.kanaka.play._
io.kanaka.play.compat.cats._
```

The ugliness of `_root_.cats._` imports is confined to `io/kanaka/play/compat/cats.scala`, which users never touch.

If you like this, it can be squashed into your initial cats commit, for a cleaner history.
