### PR TITLE
Reorganize scalaz compatibility module

### DIFF
--- a/scalaz/app/io/kanaka/play/compat/scalaz.scala
+++ b/scalaz/app/io/kanaka/play/compat/scalaz.scala
@@ -1,5 +1,6 @@
-package io.kanaka.play
+package io.kanaka.play.compat
 
+import io.kanaka.play.{Step, StepOps}
 import play.api.mvc.Result
 import _root_.scalaz.{\/, Validation, Functor, Monad}
 
@@ -8,7 +9,7 @@ import scala.language.implicitConversions
 /**
   * @author Valentin Kasas
   */
-package object scalaz {
+trait ScalazToStepOps {
 
   implicit def disjunctionToStep[A, B](disjunction: B \/ A)(implicit ec: ExecutionContext): StepOps[A, B] = new StepOps[A, B] {
     override def orFailWith(failureHandler: (B) => Result): Step[A] = Step(Future.successful(disjunction.leftMap(failureHandler).toEither), ec)
@@ -26,6 +27,10 @@ package object scalaz {
     override def orFailWith(failureHandler: (B) => Result): Step[A] = Step(futureValid.map(_.fold(failureHandler andThen Left.apply, Right.apply)), ec)
   }
 
+}
+
+trait ScalazStepInstances {
+
   implicit val stepFunctor: Functor[Step] = new Functor[Step] {
     override def map[A, B](fa: Step[A])(f: (A) => B): Step[B] = fa map f
   }
@@ -35,4 +40,7 @@ package object scalaz {
 
     override def point[A](a: => A): Step[A] = Step.unit(a)
   }
+
 }
+
+object scalaz extends ScalazStepInstances with ScalazToStepOps

--- a/scalaz/test/io/kanaka/play/ScalazStepOpsSpec.scala
+++ b/scalaz/test/io/kanaka/play/ScalazStepOpsSpec.scala
@@ -1,17 +1,18 @@
-package io.kanaka.play.scalaz
+package io.kanaka.play
 
 import controllers.ActionDSL._
+import io.kanaka.play.compat.scalaz._
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Results
 import play.api.test.{FakeApplication, PlaySpecification}
 
-import _root_.scalaz.syntax.either._
-import _root_.scalaz.syntax.validation._
-import _root_.scalaz.\/
 import scala.concurrent.Future
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scalaz.syntax.either._
+import scalaz.syntax.validation._
+
 /**
-  * @author Valentin Kasas
-  */
+ * @author Valentin Kasas
+ */
 class ScalazStepOpsSpec extends PlaySpecification with MonadicActions with Results {
 
   import scalaz._


### PR DESCRIPTION
Here's how I would organize the scalaz subproject.  Users see only clean imports:

``` scala
io.kanaka.play._
io.kanaka.play.compat.scalaz._
```

The ugliness of `_root_.scalaz._` imports is confined to `io/kanaka/play/compat/scalaz.scala`, which users never touch.

If you like this, it can be squashed into your initial scalaz commit, for a cleaner history.
