### PR TITLE
Separate modules for Scalaz 7.1 and Scalaz 7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,10 @@ version in ThisBuild := "2.0.0-SNAPSHOT"
 val commonSettings = Seq (
   resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-specs2" % "2.4.3" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.0" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.13.0" % "test",
+    "org.specs2" %% "specs2-core" % "3.7" % "test",
+    "org.specs2" %% "specs2-junit" % "3.7" % "test",
+    "com.typesafe.play" %% "play-specs2" % "2.4.6" % "test" excludeAll(ExclusionRule(organization = "org.specs2"))
   )
 )
 
@@ -12,11 +14,20 @@ lazy val core = (project in file("core")).enablePlugins(PlayScala)
   .settings(commonSettings:_*)
   .settings(name := "play-monadic-actions")
 
-lazy val scalaz = (project in file("scalaz"))
+lazy val scalaz71 = (project in file("scalaz71"))
   .settings(commonSettings:_*)
   .settings(
-    name := "play-monadic-actions-scalaz",
+    name := "play-monadic-actions-scalaz71",
     libraryDependencies ++= Seq("org.scalaz" %% "scalaz-core" % "7.1.0")
+  )
+  .dependsOn(core)
+  .enablePlugins(PlayScala)
+
+lazy val scalaz72 = (project in file("scalaz72"))
+  .settings(commonSettings:_*)
+  .settings(
+    name := "play-monadic-actions-scalaz72",
+    libraryDependencies ++= Seq("org.scalaz" %% "scalaz-core" % "7.2.1")
   )
   .dependsOn(core)
   .enablePlugins(PlayScala)

--- a/scalaz71/app
+++ b/scalaz71/app
@@ -1,0 +1,1 @@
+../scalaz/app

--- a/scalaz71/test
+++ b/scalaz71/test
@@ -1,0 +1,1 @@
+../scalaz/test

--- a/scalaz72/app
+++ b/scalaz72/app
@@ -1,0 +1,1 @@
+../scalaz/app

--- a/scalaz72/test
+++ b/scalaz72/test
@@ -1,0 +1,1 @@
+../scalaz/test


### PR DESCRIPTION
I think we should start with separate modules for Scalaz 7.1 and Scalaz 7.2 since they aren't binary compatible and both look to have a long shelf life.  Bumping to 7.2 with a new version of this lib (e.g., 2.1) would work if 7.1 was dying, but many libs are still 7.1 only.

There's some ugliness, since `play-specs2` pulls in a hard dependency on Scalaz 7.2.  I've overridden that dependency so our tests work.  Anyone trying to use Scalaz 7.2 with `play-specs2` in their app is going to have to do the same thing in their `build.sbt` though.
