### PR TITLE
Add infix variant of `-|` operator

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,5 @@
 [Damien GOUYETTE](https://twitter.com/cestpasdur)
 
 [David R. Bild](https://github.com/drbild)
+
+[Maxim Karpov](https://github.com/makkarpov)

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ From version 2.0.0 up, dependencies toward play and cats are defined as `provide
 
 [Christophe Calves](https://github.com/christophe-calves)
 
+[Maxim Karpov](https://github.com/makkarpov)
+
 ... your name here
 
 ## Credits

--- a/core/src/main/scala/io/kanaka/monadic/dsl/package.scala
+++ b/core/src/main/scala/io/kanaka/monadic/dsl/package.scala
@@ -31,10 +31,15 @@ import scala.language.implicitConversions
   */
 package object dsl {
 
+  case object escalate
+
   type JsErrorContent = Seq[(JsPath, Seq[ValidationError])]
 
   implicit class FutureOps[A](future: Future[A])(implicit ec: ExecutionContext) {
+    @deprecated("Use infix `-| escalate` instead", "2.0.1")
     def -| : Step[A] = Step(future.map(Right(_)))
+
+    def -| (escalateWord: escalate.type): Step[A] = Step(future.map(Right(_)))
   }
 
   implicit def futureToStepOps[A](future: Future[A])(

--- a/core/src/test/scala/controllers/ExampleController.scala
+++ b/core/src/test/scala/controllers/ExampleController.scala
@@ -34,7 +34,7 @@ object ExampleController extends Controller {
   def action(idStr: String) = Action.async {
     request =>
       for {
-        normed <- normalize(idStr)   .-|
+        normed <- normalize(idStr)    -| escalate
         id     <- Try(normed.toLong)  ?| BadRequest
         number <- service(id)         ?| NotFound
       } yield Ok(number.toString)

--- a/core/src/test/scala/io/kanaka/monadic/dsl/DSLSpec.scala
+++ b/core/src/test/scala/io/kanaka/monadic/dsl/DSLSpec.scala
@@ -39,6 +39,9 @@ class DSLSpec extends PlaySpecification with Results {
 
       val failedFuture = Future.failed[Int](new NullPointerException)
       await((failedFuture ?| NotFound).run) mustEqual Left(NotFound)
+
+      await((successfulFuture -| escalate).run) mustEqual Right(42)
+      await((failedFuture -| escalate).run) must throwA[NullPointerException]
     }
 
     "properly promote Future[Option[A]] to Step[A]" in {


### PR DESCRIPTION
...since points look a bit ugly. Similar to `3 seconds` vs `3 seconds span` on `scala.concurrent.duration`.

Also I not sure about `notHandled` name, maybe someone has a better variant for it.