### PR TITLE
Monad/Functor laws on cats with 2.12 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,9 @@ scalacOptions in ThisBuild ++= Seq(
   "-Xfatal-warnings"
 )
 
+crossScalaVersions := Seq("2.11.11", "2.12.2")
+
+
 val commonSettings = Seq (
   resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
   libraryDependencies ++= Seq(
@@ -56,7 +59,7 @@ lazy val cats = (project in file("cats"))
 
 
 
-publishMavenStyle in ThisBuild := true
+publishMavenStyle in ThisBuild := false
 
 pomExtra in ThisBuild := <scm>
   <url>git@github.com:Kanaka-io/play-monadic-actions.git</url>

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.2"
 
 organization in ThisBuild := "io.kanaka"
 
@@ -19,11 +19,11 @@ scalacOptions in ThisBuild ++= Seq(
 val commonSettings = Seq (
   resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play" % "2.5.3" % "provided",
-    "com.typesafe.play" %% "play-test" % "2.5.3" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.0" % "test",
-    "org.specs2" %% "specs2-core" % "3.7" % "test",
-    "com.typesafe.play" %% "play-specs2" % "2.4.6" % "test" excludeAll ExclusionRule(organization = "org.specs2")
+    "com.typesafe.play" %% "play" % "2.6.1" % "provided",
+    "com.typesafe.play" %% "play-test" % "2.6.1" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
+    "org.specs2" %% "specs2-core" % "3.9.2" % "test",
+    "com.typesafe.play" % "play-specs2_2.12" % "2.6.1" % "test"
   )
 
 )
@@ -42,15 +42,15 @@ lazy val core = (project in file("core"))
   .settings(commonSettings:_*)
   .settings(name := "play-monadic-actions")
 
-lazy val scalaz71 = scalazCompatModule(id = "scalaz71", moduleName = "play-monadic-actions-scalaz_7.1", scalazVersion = "7.1.8")
+lazy val scalaz71 = scalazCompatModule(id = "scalaz71", moduleName = "play-monadic-actions-scalaz_7.1", scalazVersion = "7.1.11")
 
-lazy val scalaz72 = scalazCompatModule(id = "scalaz72", moduleName = "play-monadic-actions-scalaz_7.2", scalazVersion = "7.2.3")
+lazy val scalaz72 = scalazCompatModule(id = "scalaz72", moduleName = "play-monadic-actions-scalaz_7.2", scalazVersion = "7.2.14")
 
 lazy val cats = (project in file("cats"))
   .settings(commonSettings:_*)
   .settings(
     name := "play-monadic-actions-cats",
-    libraryDependencies ++= Seq("org.typelevel" %% "cats" % "0.7.2" % "provided")
+    libraryDependencies ++= Seq("org.typelevel" %% "cats" % "0.9.0" % "provided")
   )
   .dependsOn(core)
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val cats = (project in file("cats"))
 
 
 
-publishMavenStyle in ThisBuild := false
+publishMavenStyle in ThisBuild := true
 
 pomExtra in ThisBuild := <scm>
   <url>git@github.com:Kanaka-io/play-monadic-actions.git</url>

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ val commonSettings = Seq (
     "com.typesafe.play" %% "play" % "2.6.1" % "provided",
     "com.typesafe.play" %% "play-test" % "2.6.1" % "test",
     "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-    "org.specs2" %% "specs2-core" % "3.9.2" % "test",
+    "org.specs2" %% "specs2-core" % "3.8.9" % "test",
+    "org.specs2" %% "specs2-scalacheck" % "3.8.9" % "test",
     "com.typesafe.play" % "play-specs2_2.12" % "2.6.1" % "test"
   )
 

--- a/cats/src/main/scala/io/kanaka/monadic/dsl/compat/cats.scala
+++ b/cats/src/main/scala/io/kanaka/monadic/dsl/compat/cats.scala
@@ -15,7 +15,7 @@
  */
 package io.kanaka.monadic.dsl.compat
 
-import _root_.cats.data.{OptionT, Validated, Xor, XorT}
+import _root_.cats.data.{OptionT, Validated}
 import _root_.cats.instances.future._
 import _root_.cats.{Functor, Monad}
 import io.kanaka.monadic.dsl.{Step, StepOps}
@@ -29,28 +29,10 @@ import scala.language.implicitConversions
   */
 trait CatsToStepOps {
 
-  implicit def xorToStep[A, B](xor: B Xor A)(
-      implicit ec: ExecutionContext): StepOps[A, B] = new StepOps[A, B] {
-    override def orFailWith(failureHandler: B => Result): Step[A] =
-      Step(Future.successful(xor.leftMap(failureHandler).toEither))
-  }
-
   implicit def validatedToStep[A, B](validated: Validated[B, A])(
-      implicit ec: ExecutionContext): StepOps[A, B] = new StepOps[A, B] {
+    implicit ec: ExecutionContext): StepOps[A, B] = new StepOps[A, B] {
     override def orFailWith(failureHandler: B => Result): Step[A] =
       Step(Future.successful(validated.leftMap(failureHandler).toEither))
-  }
-
-  implicit def futureXorToStep[A, B](futureXor: Future[B Xor A])(
-      implicit ec: ExecutionContext): StepOps[A, B] = new StepOps[A, B] {
-    override def orFailWith(failureHandler: B => Result): Step[A] =
-      Step(futureXor.map(_.leftMap(failureHandler).toEither))
-  }
-
-  implicit def xortFutureToStep[A, B](xortFuture: XorT[Future, B, A])(
-      implicit ec: ExecutionContext): StepOps[A, B] = new StepOps[A, B] {
-    override def orFailWith(failureHandler: B => Result): Step[A] =
-      Step(xortFuture.leftMap(failureHandler).toEither)
   }
 
   implicit def optiontFutureToStep[A](optiontFuture: OptionT[Future, A])(
@@ -86,7 +68,7 @@ trait CatsStepInstances {
       override def pure[A](x: A): Step[A] = Step.unit(x)
 
       override def tailRecM[A, B](a: A)(f: (A) => Step[Either[A, B]]): Step[B] =
-        defaultTailRecM(a)(f) // maybe not the best thing to do
+        tailRecM(a)(f) // maybe not the best thing to do
     }
 
 }

--- a/cats/src/test/scala/io/kanaka/monadic/dsl/CatsStepMonadSpec
+++ b/cats/src/test/scala/io/kanaka/monadic/dsl/CatsStepMonadSpec
@@ -1,0 +1,34 @@
+package io.kanaka.monadic.dsl
+
+import cats.Eq
+import cats.laws.discipline.MonadTests
+import io.kanaka.monadic.dsl.compat.cats.stepMonad
+import org.specs2.mutable._
+import org.specs2.matcher.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import cats.instances.all._
+import org.scalacheck.Arbitrary
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class CatsStepMonadSpec extends Specification with Matchers with Discipline {
+
+  private implicit def arbitraryStep[T: Arbitrary]: Arbitrary[Step[T]] =
+    Arbitrary {
+      implicitly[Arbitrary[T]].arbitrary map { value =>
+        Step.unit(value)
+      }
+    }
+
+  private implicit def stepEq[T: Eq]: Eq[Step[T]] =
+    (x: Step[T], y: Step[T]) => {
+      x.run === y.run
+    }
+
+  "x" should {
+    "y" in {
+      checkAll("Monad[Step]", MonadTests[Step].monad[Int, Int, Int])
+    }
+  }
+
+}

--- a/cats/src/test/scala/io/kanaka/monadic/dsl/CatsStepOpsSpec.scala
+++ b/cats/src/test/scala/io/kanaka/monadic/dsl/CatsStepOpsSpec.scala
@@ -15,12 +15,13 @@
  */
 package io.kanaka.monadic.dsl
 
-import cats.data.{OptionT, Validated, Xor, XorT}
+import cats.data.{OptionT, Validated}
 import cats.instances.future._
 import io.kanaka.monadic.dsl.compat.cats._
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.mvc.Results
-import play.api.test.{FakeApplication, PlaySpecification}
+import play.api.test.PlaySpecification
+import play.test.Helpers
 
 import scala.concurrent.Future
 
@@ -29,33 +30,9 @@ import scala.concurrent.Future
   */
 class CatsStepOpsSpec extends PlaySpecification with Results {
 
-  implicit val app = FakeApplication()
+  implicit val app = Helpers.fakeApplication()
 
   "ActionDSL.cats" should {
-
-    "properly promote B Xor A to Step[A]" in {
-      val aRight: String Xor Int = Xor.right(42)
-      await((aRight ?| NotFound).run) mustEqual Right(42)
-
-      val aLeft: String Xor Int = Xor.left("Error")
-      await((aLeft ?| NotFound).run) mustEqual Left(NotFound)
-    }
-
-    "properly promote Future[B Xor A] to Step[A]" in {
-      val futureRight: Future[Xor[Nothing, Int]] = Future.successful(Xor.right(42))
-      await((futureRight ?| NotFound).run) mustEqual Right(42)
-
-      val futureLeft = Future.successful(Xor.left("Error"))
-      await((futureLeft ?| NotFound).run) mustEqual Left(NotFound)
-    }
-
-    "properly promote XorT[Future, B, A] to Step[A]" in {
-      val xortFutureRight: XorT[Future, Unit, Int] = XorT.fromXor[Future](Xor.right(42))
-      await((xortFutureRight ?| NotFound).run) mustEqual Right(42)
-
-      val futureLeft: XorT[Future, String, Unit] = XorT.fromXor[Future](Xor.left("Error"))
-      await((futureLeft ?| NotFound).run) mustEqual Left(NotFound)
-    }
 
     "properly promote OptionT[Future, A] to Step[A]" in {
       val optiontFutureRight: OptionT[Future, Int] = OptionT.fromOption[Future](Option(42))

--- a/core/src/main/scala/io/kanaka/monadic/dsl/package.scala
+++ b/core/src/main/scala/io/kanaka/monadic/dsl/package.scala
@@ -15,7 +15,6 @@
  */
 package io.kanaka.monadic
 
-import play.api.data.validation.ValidationError
 import play.api.libs.json.JsPath
 import play.api.mvc.Result
 import play.api.data.Form
@@ -33,7 +32,7 @@ package object dsl {
 
   case object escalate
 
-  type JsErrorContent = Seq[(JsPath, Seq[ValidationError])]
+  type JsErrorContent = Seq[(JsPath, Seq[play.api.libs.json.JsonValidationError])]
 
   implicit class FutureOps[A](future: Future[A])(implicit ec: ExecutionContext) {
     @deprecated("Use infix `-| escalate` instead", "2.0.1")

--- a/core/src/test/scala/controllers/ExampleController.scala
+++ b/core/src/test/scala/controllers/ExampleController.scala
@@ -15,16 +15,18 @@
  */
 package controllers
 
-import play.api.mvc.{Action, Controller}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import javax.inject.Inject
+
+import play.api.mvc.{BaseController, ControllerComponents}
+
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
-
 import io.kanaka.monadic.dsl._
 /**
   * @author Valentin Kasas
   */
-object ExampleController extends Controller {
+class ExampleController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
 
 
   def normalize(idStr: String) = Future.successful(idStr.trim)

--- a/core/src/test/scala/controllers/MonadicActionsController.scala
+++ b/core/src/test/scala/controllers/MonadicActionsController.scala
@@ -20,13 +20,13 @@ import javax.inject.Inject
 import io.kanaka.monadic.dsl._
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc.InjectedController
+import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.i18n.Messages
 
 // the fact that this file compiles proves that https://github.com/Kanaka-io/play-monadic-actions/issues/1 is solved
 @Inject
-class MonadicActionsController(messages: Messages) extends Controller {
+class MonadicActionsController(messages: Messages) extends InjectedController {
 
   val twoFieldForm = Form(
     tuple("id" -> longNumber,

--- a/core/src/test/scala/io/kanaka/monadic/dsl/DSLSpec.scala
+++ b/core/src/test/scala/io/kanaka/monadic/dsl/DSLSpec.scala
@@ -17,9 +17,11 @@ package io.kanaka.monadic.dsl
 
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.i18n._
 import play.api.libs.json.{JsError, JsSuccess}
 import play.api.mvc.{Result, Results}
-import play.api.test.{FakeApplication, PlaySpecification}
+import play.api.test.PlaySpecification
+import play.test.Helpers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -29,7 +31,9 @@ import scala.util.{Failure, Success}
  */
 class DSLSpec extends PlaySpecification with Results {
 
-  implicit val app = FakeApplication()
+  implicit val app = Helpers.fakeApplication()
+
+  implicit val messages = MessagesImpl(Lang.defaultLang, new DefaultMessagesApi())
 
   "dsl" should {
 

--- a/core/src/test/scala/io/kanaka/monadic/dsl/StepSpecification.scala
+++ b/core/src/test/scala/io/kanaka/monadic/dsl/StepSpecification.scala
@@ -19,7 +19,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop._
 import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
 import play.api.mvc.{Result, Results}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.2.6")
 

--- a/scalaz/src/test/scala/io/kanaka/monadic/dsl/ScalazMonadLawsSpecs.scala
+++ b/scalaz/src/test/scala/io/kanaka/monadic/dsl/ScalazMonadLawsSpecs.scala
@@ -1,0 +1,5 @@
+package io.kanaka.monadic.dsl
+
+class ScalazMonadLawsSpecs {
+
+}

--- a/scalaz/src/test/scala/io/kanaka/monadic/dsl/ScalazStepOpsSpec.scala
+++ b/scalaz/src/test/scala/io/kanaka/monadic/dsl/ScalazStepOpsSpec.scala
@@ -15,10 +15,9 @@
  */
 package io.kanaka.monadic.dsl
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Results
-import play.api.test.{FakeApplication, PlaySpecification}
-
+import play.api.test.PlaySpecification
+import scala.concurrent.ExecutionContext.Implicits.global
 import compat.scalaz._
 
 import scala.concurrent.Future
@@ -34,7 +33,7 @@ class ScalazStepOpsSpec extends PlaySpecification with Results {
 
   import scalaz._
 
-  implicit val app = FakeApplication()
+  implicit val app = play.test.Helpers.fakeApplication()
 
   "ActionDSL.scalaz" should {
 


### PR DESCRIPTION
I add a quick test for monad and functor laws on Cats. I was attempting to add the same for scalaz as well, but the [specs2-scalaz](https://github.com/typelevel/scalaz-specs2) library isn't ready for 2.12 yet it seems. Maybe this is something to come back to?