### PR TITLE
Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
  language: scala
  scala:
-   - "2.13.1"
+   - "2.13.0"
  jdk:
    - openjdk11
  before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
  language: scala
  scala:
    - "2.13.0"
+   - "2.12.10"
+   - "2.11.12"
  jdk:
    - openjdk11
  before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
  language: scala
  scala:
-   - "2.11.7"
+   - "2.13.1"
  jdk:
-   - oraclejdk8
+   - openjdk11
  before_script:
   - sudo chmod +x /usr/local/bin/sbt
  script:

--- a/README.md
+++ b/README.md
@@ -144,18 +144,17 @@ The DSL supports the following conversions :
 
 Using sbt :
 
-Current version is 2.1.0
+Current version is 2.2.0
 ~~~scala
-libraryDependencies += "io.kanaka" %% "play-monadic-actions" % "2.1.0"
+libraryDependencies += "io.kanaka" %% "play-monadic-actions" % "2.2.0"
 ~~~
 
 There are also contrib modules for interoperability with scalaz and cats : 
 
 |module name|is compatible with / built against|
 | --- | --- |
-|play-monadic-actions-cats| cats 0.7.2|
-|play-monadic-actions-scalaz_7-1| scalaz 7.1.8|
-|play-monadic-actions-scalaz_7-2| scalaz 7.2.3|
+|play-monadic-actions-cats| cats 2.0.0|
+|play-monadic-actions-scalaz_7-2| scalaz 7.2.28|
 
 Each of these module provides `Functor` and `Monad` instances for `Step[_]` as well as conversions for relevant types in the target library 
 
@@ -163,6 +162,7 @@ These instances and conversions are made available by importing `io.kanaka.monad
  
 ## Compatibility
 
+- Version `2.2.0` is compatible with Play! `2.7.x`
 - Version `2.1.0` is compatible with Play! `2.6.x`
 - Version `2.0.0` is compatible with Play! `2.5.x`
 - Version `1.1.0` is compatible with Play! `2.4.x`

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion in ThisBuild := "2.12.8"
+scalaVersion in ThisBuild := "2.13.1"
 
 organization in ThisBuild := "io.kanaka"
 
@@ -16,18 +16,18 @@ scalacOptions in ThisBuild ++= Seq(
   "-Xfatal-warnings"
 )
 
-crossScalaVersions := Seq("2.11.11", "2.12.8")
+crossScalaVersions := Seq("2.11.11", "2.12.8", "2.13.1")
 
 
 val commonSettings = Seq (
-  resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
+  resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play" % "2.6.2" % "provided",
-    "com.typesafe.play" %% "play-test" % "2.6.2" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",
-    "org.specs2" %% "specs2-core" % "3.9.4" % "test",
-    "org.specs2" %% "specs2-scalacheck" % "3.9.4" % "test",
-    "com.typesafe.play" %% "play-specs2" % "2.6.2" % "test" 
+    "com.typesafe.play" %% "play" % "2.7.3" % "provided",
+    "com.typesafe.play" %% "play-test" % "2.7.3" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.14.1" % "test",
+    "org.specs2" %% "specs2-core" % "4.7.1" % "test",
+    "org.specs2" %% "specs2-scalacheck" % "4.7.1" % "test",
+    "com.typesafe.play" %% "play-specs2" % "2.7.3" % "test" 
   )
 
 )
@@ -46,16 +46,14 @@ lazy val core = (project in file("core"))
   .settings(commonSettings:_*)
   .settings(name := "play-monadic-actions")
 
-lazy val scalaz71 = scalazCompatModule(id = "scalaz71", moduleName = "play-monadic-actions-scalaz_7.1", scalazVersion = "7.1.14")
-
-lazy val scalaz72 = scalazCompatModule(id = "scalaz72", moduleName = "play-monadic-actions-scalaz_7.2", scalazVersion = "7.2.14")
+lazy val scalaz72 = scalazCompatModule(id = "scalaz72", moduleName = "play-monadic-actions-scalaz_7.2", scalazVersion = "7.2.28")
 
 lazy val cats = (project in file("cats"))
   .settings(commonSettings:_*)
   .settings(
     name := "play-monadic-actions-cats",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % "1.6.0" % "provided"
+      "org.typelevel" %% "cats-core" % "2.0.0" % "provided"
     )
   )
   .dependsOn(core % "compile->compile;test->test")
@@ -86,4 +84,4 @@ publishTo in ThisBuild := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
-releasePublishArtifactsAction := com.typesafe.sbt.pgp.PgpKeys.publishSigned.value
+releasePublishArtifactsAction := com.jsuereth.sbtpgp.PgpKeys.publishSigned.value

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion in ThisBuild := "2.13.1"
+scalaVersion in ThisBuild := "2.13.0"
 
 organization in ThisBuild := "io.kanaka"
 
@@ -16,7 +16,7 @@ scalacOptions in ThisBuild ++= Seq(
   "-Xfatal-warnings"
 )
 
-crossScalaVersions := Seq("2.11.11", "2.12.8", "2.13.1")
+crossScalaVersions := Seq("2.11.11", "2.12.8", "2.13.0")
 
 
 val commonSettings = Seq (

--- a/core/src/main/scala/io/kanaka/monadic/dsl/Step.scala
+++ b/core/src/main/scala/io/kanaka/monadic/dsl/Step.scala
@@ -15,7 +15,7 @@
  */
 package io.kanaka.monadic.dsl
 
-import play.api.mvc.{Result, Results}
+import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,7 +25,7 @@ import scala.concurrent.{ExecutionContext, Future}
 final case class Step[+A](run: Future[Either[Result, A]]) {
 
   def map[B](f: A => B)(implicit ec: ExecutionContext) =
-    copy(run = run.map(_.right.map(f)))
+    copy(run = run.map(_.map(f)))
 
   def flatMap[B](f: A => Step[B])(implicit ec: ExecutionContext) =
     copy(run = run.flatMap(_.fold(err =>

--- a/core/src/main/scala/io/kanaka/monadic/dsl/package.scala
+++ b/core/src/main/scala/io/kanaka/monadic/dsl/package.scala
@@ -32,7 +32,7 @@ package object dsl {
 
   case object escalate
 
-  type JsErrorContent = Seq[(JsPath, Seq[play.api.libs.json.JsonValidationError])]
+  type JsErrorContent = collection.Seq[(JsPath, collection.Seq[play.api.libs.json.JsonValidationError])]
 
   implicit class FutureOps[A](future: Future[A])(implicit ec: ExecutionContext) {
     @deprecated("Use infix `-| escalate` instead", "2.0.1")

--- a/core/src/test/scala/io/kanaka/monadic/dsl/DSLSpec.scala
+++ b/core/src/test/scala/io/kanaka/monadic/dsl/DSLSpec.scala
@@ -65,7 +65,7 @@ class DSLSpec extends PlaySpecification with Results {
       val step = leftFuture ?| (s => BadRequest(s))
       await(step.run) must beLeft
 
-      val result = step.run.map(_.swap.right.getOrElse(NotFound))
+      val result = step.run.map(_.swap.getOrElse(NotFound))
       status(result) mustEqual 400
 
       contentAsString(result) must contain("foo")
@@ -87,7 +87,7 @@ class DSLSpec extends PlaySpecification with Results {
       val step = left ?| (s => BadRequest(s))
       await(step.run) must beLeft
 
-      val result:Future[Result] = step.run.map(_.swap.right.getOrElse(NotFound))
+      val result:Future[Result] = step.run.map(_.swap.getOrElse(NotFound))
       status(result) mustEqual 400
 
       contentAsString(result) must contain ("foo")
@@ -101,7 +101,7 @@ class DSLSpec extends PlaySpecification with Results {
       val step = jsError ?| (e => BadRequest(JsError.toJson(e)))
       await(step.run) must beLeft
 
-      val result = step.run.map(_.swap.right.getOrElse(NotFound))
+      val result = step.run.map(_.swap.getOrElse(NotFound))
       status(result) mustEqual 400
 
       contentAsString(result) must contain(JsError.toJson(jsError).toString())
@@ -116,7 +116,7 @@ class DSLSpec extends PlaySpecification with Results {
       val step = erroneousForm ?| (f => BadRequest(f.errorsAsJson))
       await(step.run) must beLeft
 
-      val result = step.run.map(_.swap.right.getOrElse(NotFound))
+      val result = step.run.map(_.swap.getOrElse(NotFound))
       status(result) mustEqual 400
 
       contentAsString(result) must contain(erroneousForm.errorsAsJson.toString())
@@ -140,7 +140,7 @@ class DSLSpec extends PlaySpecification with Results {
       val step = failure ?| (e => BadRequest(e.getMessage))
       await(step.run) must beLeft
 
-      val result: Future[Result] = step.run.map(_.swap.right.getOrElse(NotFound))
+      val result: Future[Result] = step.run.map(_.swap.getOrElse(NotFound))
       status(result) mustEqual 400
 
       contentAsString(result) must contain("foo")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 template.uuid=2e740af7-cd0e-49d3-a9c6-dab833026508
-sbt.version=1.3.0
+sbt.version=1.3.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,2 @@
-#Activator-generated Properties
-#Sat Dec 13 20:11:40 CET 2014
 template.uuid=2e740af7-cd0e-49d3-a9c6-dab833026508
-sbt.version=0.13.13
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,9 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.5")
 
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.2.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.1-SNAPSHOT"
+version in ThisBuild := "2.2.0-SNAPSHOT"


### PR DESCRIPTION
This adds support for Scala 2.13.

I couldn't load the project due to SBT 0.13 and old plugins. Not really sure why, but I upgraded to SBT 1.3.0 (which has the benefit of being _much_ faster) and the plugins. Once I did that everything was good again.

I had to drop Scalaz 7.1 because it doesn't support Scala 2.13.

Cats 2.0.0 was recently released with Scala 2.13 support, so I updated that as well.

And I fixed the breaking changes associated with Scala 2.13.

If there's anything I missed, let me know. Thanks.